### PR TITLE
Add PR login preview workflow

### DIFF
--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -110,11 +110,10 @@ jobs:
 
             const file = await fs.promises.readFile(screenshotPath);
             const upload = await github.request(
-              'POST /repos/{owner}/{repo}/issues/{issue_number}/comments/{comment_id}/attachments',
+              'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/attachments',
               {
                 owner,
                 repo,
-                issue_number,
                 comment_id: targetComment.id,
                 name: 'green-sky-login.png',
                 file: file.toString('base64'),

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -18,10 +18,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tests/playwright/package-lock.json
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/playwright/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright dependencies
         working-directory: tests/playwright
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright browser
         working-directory: tests/playwright
@@ -81,7 +91,7 @@ jobs:
 
           curl --fail-with-body -sS \
             -F "file=@tests/playwright/artifacts/green-sky-login.png" \
-            -F "payload_json={\"content\":\"Green Sky login preview for PR #${{ github.event.number }}\"}" \
+            -F "payload_json={\"content\":\"Green Sky login preview for PR #${{ github.event.number }}: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}\"}" \
             "$DISCORD_WEBHOOK_URL"
 
       - name: Teardown environment

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -76,7 +76,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const core = require('@actions/core');
 
             const screenshotPath = 'tests/playwright/artifacts/green-sky-login.png';
             if (!fs.existsSync(screenshotPath)) {

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -1,0 +1,60 @@
+name: Preview themed login
+
+on:
+  pull_request:
+
+jobs:
+  preview:
+    name: Build & capture login preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright dependencies
+        working-directory: tests/playwright
+        run: npm install
+
+      - name: Install Playwright browser
+        working-directory: tests/playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Keycloak
+        run: docker compose up -d keycloak
+
+      - name: Wait for Keycloak to be ready
+        run: |
+          for attempt in {1..30}; do
+            if curl -fsS http://localhost:8080/realms/master/.well-known/openid-configuration > /dev/null; then
+              exit 0
+            fi
+            echo "Keycloak is not ready yet (attempt ${attempt}). Waiting..."
+            sleep 5
+          done
+          echo "Keycloak did not become ready in time" >&2
+          docker compose logs keycloak
+          exit 1
+
+      - name: Run Playwright tests
+        working-directory: tests/playwright
+        run: npm test
+
+      - name: Upload Playwright artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: login-page-preview
+          path: |
+            tests/playwright/test-results/**/*
+            tests/playwright/playwright-report
+          if-no-files-found: error
+
+      - name: Teardown environment
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,18 +63,73 @@ jobs:
         run: |
           if [ -f tests/playwright/artifacts/green-sky-login.png ]; then
             echo '## Login preview' >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "![Green Sky login](data:image/png;base64,$(base64 -w0 tests/playwright/artifacts/green-sky-login.png))" >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo 'Screenshot posted as a PR comment attachment.' >> "$GITHUB_STEP_SUMMARY"
           else
             echo 'Login screenshot was not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload Playwright artifacts
-        uses: actions/upload-artifact@v4
+      - name: Post login screenshot comment
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
         with:
-          name: login-page-preview
-          path: tests/playwright/artifacts/green-sky-login.png
-          if-no-files-found: error
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const core = require('@actions/core');
+
+            const screenshotPath = 'tests/playwright/artifacts/green-sky-login.png';
+            if (!fs.existsSync(screenshotPath)) {
+              core.warning('Login screenshot not found; skipping PR comment update.');
+              return;
+            }
+
+            const marker = '<!-- green-sky-login-preview -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            let targetComment = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (!targetComment) {
+              const { data } = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `${marker}\nPreparing login screenshot…`,
+              });
+              targetComment = data;
+            }
+
+            const file = await fs.promises.readFile(screenshotPath);
+            const upload = await github.request(
+              'POST /repos/{owner}/{repo}/issues/{issue_number}/comments/{comment_id}/attachments',
+              {
+                owner,
+                repo,
+                issue_number,
+                comment_id: targetComment.id,
+                name: 'green-sky-login.png',
+                file: file.toString('base64'),
+              }
+            );
+
+            const assetUrl = upload.data.attachment.url;
+
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: targetComment.id,
+              body: `${marker}\n![Green Sky login](${assetUrl})`,
+            });
 
       - name: Teardown environment
         if: always()

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -64,70 +64,25 @@ jobs:
           if [ -f tests/playwright/artifacts/green-sky-login.png ]; then
             echo '## Login preview' >> "$GITHUB_STEP_SUMMARY"
             echo >> "$GITHUB_STEP_SUMMARY"
-            echo 'Screenshot posted as a PR comment attachment.' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Screenshot posted to Discord via webhook.' >> "$GITHUB_STEP_SUMMARY"
           else
             echo 'Login screenshot was not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Post login screenshot comment
+      - name: Send login screenshot to Discord
         if: ${{ always() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ ! -f tests/playwright/artifacts/green-sky-login.png ]; then
+            echo "Login screenshot not found; skipping Discord upload." >&2
+            exit 0
+          fi
 
-            const screenshotPath = 'tests/playwright/artifacts/green-sky-login.png';
-            if (!fs.existsSync(screenshotPath)) {
-              core.warning('Login screenshot not found; skipping PR comment update.');
-              return;
-            }
-
-            const marker = '<!-- green-sky-login-preview -->';
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-
-            let targetComment = comments.find(
-              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            );
-
-            if (!targetComment) {
-              const { data } = await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body: `${marker}\nPreparing login screenshot…`,
-              });
-              targetComment = data;
-            }
-
-            const file = await fs.promises.readFile(screenshotPath);
-            const upload = await github.request(
-              'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/attachments',
-              {
-                owner,
-                repo,
-                comment_id: targetComment.id,
-                name: 'green-sky-login.png',
-                file: file.toString('base64'),
-              }
-            );
-
-            const assetUrl = upload.data.attachment.url;
-
-            await github.rest.issues.updateComment({
-              owner,
-              repo,
-              comment_id: targetComment.id,
-              body: `${marker}\n![Green Sky login](${assetUrl})`,
-            });
+          curl --fail-with-body -sS \
+            -F "file=@tests/playwright/artifacts/green-sky-login.png" \
+            -F "payload_json={\"content\":\"Green Sky login preview for PR #${{ github.event.number }}\"}" \
+            "$DISCORD_WEBHOOK_URL"
 
       - name: Teardown environment
         if: always()

--- a/.github/workflows/preview-login.yml
+++ b/.github/workflows/preview-login.yml
@@ -46,13 +46,33 @@ jobs:
         working-directory: tests/playwright
         run: npm test
 
+      - name: Gather login screenshot
+        if: always()
+        run: |
+          mkdir -p tests/playwright/artifacts
+          SCREENSHOT=$(find tests/playwright/test-results -name green-sky-login.png -print -quit)
+          if [ -n "$SCREENSHOT" ] && [ -f "$SCREENSHOT" ]; then
+            cp "$SCREENSHOT" tests/playwright/artifacts/green-sky-login.png
+          else
+            echo "Login screenshot not found" >&2
+          fi
+
+      - name: Publish login screenshot summary
+        if: always()
+        run: |
+          if [ -f tests/playwright/artifacts/green-sky-login.png ]; then
+            echo '## Login preview' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "![Green Sky login](data:image/png;base64,$(base64 -w0 tests/playwright/artifacts/green-sky-login.png))" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Login screenshot was not generated.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         with:
           name: login-page-preview
-          path: |
-            tests/playwright/test-results/**/*
-            tests/playwright/playwright-report
+          path: tests/playwright/artifacts/green-sky-login.png
           if-no-files-found: error
 
       - name: Teardown environment

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+tests/playwright/playwright-report/
+tests/playwright/test-results/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
     volumes:
       - ./theme/green-sky-login:/opt/keycloak/themes/green-sky-login
+      - ./realm:/opt/keycloak/data/import
     command:
       - start-dev
+      - --import-realm
     ports:
       - "8080:8080"

--- a/realm/green-sky-realm.json
+++ b/realm/green-sky-realm.json
@@ -1,0 +1,75 @@
+{
+  "id": "green-sky",
+  "realm": "green-sky",
+  "displayName": "Green Sky",
+  "enabled": true,
+  "loginTheme": "green-sky-login",
+  "registrationAllowed": false,
+  "rememberMe": true,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "internationalizationEnabled": false,
+  "clients": [
+    {
+      "clientId": "login-app",
+      "name": "Login preview",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "http://localhost:8080/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "rootUrl": "http://localhost:8080",
+      "adminUrl": "http://localhost:8080",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "web-origins",
+    "roles",
+    "profile",
+    "email"
+  ],
+  "defaultOptionalClientScopes": [
+    "address",
+    "phone",
+    "offline_access",
+    "microprofile-jwt"
+  ],
+  "users": [
+    {
+      "username": "theme-viewer",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theme",
+      "lastName": "Viewer",
+      "email": "theme.viewer@example.com",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "green-sky-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "green-sky-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.45.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "green-sky-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.3"
+  }
+}

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  timeout: 120_000,
+  retries: 0,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }]
+  ],
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+    screenshot: 'off'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/tests/playwright/specs/login-preview.spec.ts
+++ b/tests/playwright/specs/login-preview.spec.ts
@@ -13,7 +13,7 @@ test('log in to admin console and capture themed login page', async ({ page }, t
   await page.goto('/admin/');
 
   await page.getByLabel(/username or email/i).fill(ADMIN_USERNAME);
-  await page.getByLabel(/password/i).fill(ADMIN_PASSWORD);
+  await page.locator('input[name="password"]').fill(ADMIN_PASSWORD);
   await page.getByRole('button', { name: /sign in/i }).click();
 
   await page.waitForURL('**/admin/master/console/**', { timeout: 30_000 });

--- a/tests/playwright/specs/login-preview.spec.ts
+++ b/tests/playwright/specs/login-preview.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+const ADMIN_USERNAME = process.env.KC_BOOTSTRAP_ADMIN_USERNAME ?? 'admin';
+const ADMIN_PASSWORD = process.env.KC_BOOTSTRAP_ADMIN_PASSWORD ?? 'admin';
+
+const LOGIN_PREVIEW_URL = '/realms/green-sky/protocol/openid-connect/auth' +
+  '?response_type=code' +
+  '&scope=openid' +
+  '&client_id=login-app' +
+  '&redirect_uri=' + encodeURIComponent('http://localhost:8080/realms/green-sky/account/');
+
+test('log in to admin console and capture themed login page', async ({ page }, testInfo) => {
+  await page.goto('/admin/');
+
+  await page.getByLabel(/username or email/i).fill(ADMIN_USERNAME);
+  await page.getByLabel(/password/i).fill(ADMIN_PASSWORD);
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  await page.waitForURL('**/admin/master/console/**', { timeout: 30_000 });
+
+  await page.context().clearCookies();
+  await page.goto('about:blank');
+
+  await page.goto(LOGIN_PREVIEW_URL);
+  await expect(page.locator('.login-hero-title')).toHaveText('Welcome to your workspace');
+
+  const screenshotPath = testInfo.outputPath('green-sky-login.png');
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach('green-sky-login', {
+    path: screenshotPath,
+    contentType: 'image/png'
+  });
+});


### PR DESCRIPTION
## Summary
- add a pull-request workflow that spins up Keycloak, runs Playwright, and uploads the themed login screenshot
- add a realm import and Playwright test project that logs in with the bootstrap admin and captures the themed login page

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9ed72cbdc832c8276226fc88bcb39